### PR TITLE
add functionality to support groups

### DIFF
--- a/pyhole_updatelists/http_actions.py
+++ b/pyhole_updatelists/http_actions.py
@@ -18,7 +18,7 @@ def send_it(http_request: dict) -> str:
     if not http_request.get("verify", True):
         warnings.simplefilter("ignore", InsecureRequestWarning)
     response = requests.request(
-        url=requests.utils.requote_uri(http_request["url"]),  # type: ignore
+        url=http_request["url"],
         method=http_request["method"],
         headers=http_request.get("headers", None),
         json=http_request.get("body", None),

--- a/pyhole_updatelists/settings.py
+++ b/pyhole_updatelists/settings.py
@@ -17,4 +17,5 @@ def load_settings() -> dict:
     app_config["LOG_LEVEL"] = app_config["LOG_LEVEL"].upper()
     app_config["UPDATE_GRAVITY"] = string_to_bool(app_config["UPDATE_GRAVITY"])
     app_config["VERIFY_SSL"] = string_to_bool(app_config["VERIFY_SSL"])
+    app_config["GROUP_ID"] = int(app_config["GROUP_ID"])
     return app_config

--- a/pyhole_updatelists/utils.py
+++ b/pyhole_updatelists/utils.py
@@ -10,7 +10,7 @@ def is_valid_regex(pattern):
 
 
 def string_to_bool(s):
-    if isinstance(s, bool) == bool:
+    if isinstance(s, bool):
         return s
     if s.lower() == "false":
         return False


### PR DESCRIPTION
allow group_id to affect list/domain membership. Will toggle group membership based on group_id and not affect other groups. Using group_id is the primary method to disable/enable block lists